### PR TITLE
Fix build error when `ddsfile` feature is omitted

### DIFF
--- a/image_dds/src/error.rs
+++ b/image_dds/src/error.rs
@@ -1,6 +1,8 @@
 use thiserror::Error;
 
-use crate::{DdsFormatInfo, ImageFormat};
+use crate::ImageFormat;
+#[cfg(feature = "ddsfile")]
+use crate::DdsFormatInfo;
 
 /// Errors that can occur while creating a decoded image.
 #[derive(Debug, Error)]
@@ -53,6 +55,7 @@ pub enum SurfaceError {
     #[error("failed to get image data for layer {layer} mipmap {mipmap}")]
     MipmapDataOutOfBounds { layer: u32, mipmap: u32 },
 
+    #[cfg(feature = "ddsfile")]
     #[error("DDS image format {0:?} is not supported")]
     UnsupportedDdsFormat(DdsFormatInfo),
 


### PR DESCRIPTION
Title.

Don't need `dds` support for my consumption, so running without the `ddsfile` feature. Error module pulls in a `ddsfile`-only struct, leading to a build error. This PR just gates that import and error variant.