### PR TITLE
bcdec_rs/image_dds: add BC4 and BC5 SNORM variants

### DIFF
--- a/image_dds/src/bcn.rs
+++ b/image_dds/src/bcn.rs
@@ -16,6 +16,8 @@ pub struct Bc1;
 pub struct Bc2;
 pub struct Bc3;
 pub struct Bc4;
+pub struct Bc4S;
 pub struct Bc5;
+pub struct Bc5S;
 pub struct Bc6;
 pub struct Bc7;

--- a/image_dds/src/bcn/decode.rs
+++ b/image_dds/src/bcn/decode.rs
@@ -2,7 +2,7 @@ use bytemuck::Pod;
 
 use crate::{error::SurfaceError, mip_size};
 
-use super::{Bc1, Bc2, Bc3, Bc4, Bc5, Bc6, Bc7, BLOCK_HEIGHT, BLOCK_WIDTH, CHANNELS};
+use super::{Bc1, Bc2, Bc3, Bc4, Bc4S, Bc5, Bc5S, Bc6, Bc7, BLOCK_HEIGHT, BLOCK_WIDTH, CHANNELS};
 
 pub trait BcnDecode<Pixel> {
     type CompressedBlock;
@@ -94,6 +94,37 @@ impl BcnDecode<[u8; 4]> for Bc4 {
             block,
             bytemuck::cast_slice_mut(&mut decompressed_r),
             BLOCK_WIDTH,
+            false,
+        );
+
+        // Pad to RGBA with alpha set to white.
+        let mut decompressed = [[[0u8; 4]; BLOCK_WIDTH]; BLOCK_HEIGHT];
+        for y in 0..BLOCK_HEIGHT {
+            for x in 0..BLOCK_WIDTH {
+                // It's a convention in some programs display BC4 in the red channel.
+                // Use grayscale instead to avoid confusing it with colored data.
+                // TODO: Match how channels handled when compressing RGBA data to BC4?
+                let r = decompressed_r[y][x];
+                decompressed[y][x] = [r, r, r, 255u8];
+            }
+        }
+
+        decompressed
+    }
+}
+
+impl BcnDecode<[u8; 4]> for Bc4S {
+    type CompressedBlock = [u8; 8];
+
+    fn decompress_block(block: &[u8; 8]) -> [[[u8; 4]; BLOCK_WIDTH]; BLOCK_HEIGHT] {
+        // BC4 stores grayscale data, so each decompressed pixel is 1 byte.
+        let mut decompressed_r = [[0u8; BLOCK_WIDTH]; BLOCK_HEIGHT];
+
+        bcdec_rs::bc4(
+            block,
+            bytemuck::cast_slice_mut(&mut decompressed_r),
+            BLOCK_WIDTH,
+            true,
         );
 
         // Pad to RGBA with alpha set to white.
@@ -123,6 +154,35 @@ impl BcnDecode<[u8; 4]> for Bc5 {
             block,
             bytemuck::cast_slice_mut(&mut decompressed_rg),
             BLOCK_WIDTH * 2,
+            false,
+        );
+
+        // Pad to RGBA with alpha set to white.
+        let mut decompressed = [[[0u8; 4]; BLOCK_WIDTH]; BLOCK_HEIGHT];
+        for y in 0..BLOCK_HEIGHT {
+            for x in 0..BLOCK_HEIGHT {
+                // It's convention to zero the blue channel when decompressing BC5.
+                let [r, g] = decompressed_rg[y][x];
+                decompressed[y][x] = [r, g, 0u8, 255u8];
+            }
+        }
+
+        decompressed
+    }
+}
+
+impl BcnDecode<[u8; 4]> for Bc5S {
+    type CompressedBlock = [u8; 16];
+
+    fn decompress_block(block: &[u8; 16]) -> [[[u8; 4]; BLOCK_WIDTH]; BLOCK_HEIGHT] {
+        // BC5 stores RG data, so each decompressed pixel is 2 bytes.
+        let mut decompressed_rg = [[[0u8; 2]; BLOCK_WIDTH]; BLOCK_HEIGHT];
+
+        bcdec_rs::bc5(
+            block,
+            bytemuck::cast_slice_mut(&mut decompressed_rg),
+            BLOCK_WIDTH * 2,
+            true,
         );
 
         // Pad to RGBA with alpha set to white.

--- a/image_dds/src/decode.rs
+++ b/image_dds/src/decode.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     ImageFormat, Surface, SurfaceRgba32Float, SurfaceRgba8,
 };
-use bcn::{Bc1, Bc2, Bc3, Bc4, Bc5, Bc6, Bc7};
+use bcn::{Bc1, Bc2, Bc3, Bc4, Bc4S, Bc5, Bc5S, Bc6, Bc7};
 
 impl<T: AsRef<[u8]>> Surface<T> {
     /// Decode all layers and mipmaps from `surface` to RGBA8.
@@ -122,8 +122,10 @@ impl Decode for u8 {
             F::BC1RgbaUnorm | F::BC1RgbaUnormSrgb => rgba_from_bcn::<Bc1, u8>(width, height, data),
             F::BC2RgbaUnorm | F::BC2RgbaUnormSrgb => rgba_from_bcn::<Bc2, u8>(width, height, data),
             F::BC3RgbaUnorm | F::BC3RgbaUnormSrgb => rgba_from_bcn::<Bc3, u8>(width, height, data),
-            F::BC4RUnorm | F::BC4RSnorm => rgba_from_bcn::<Bc4, u8>(width, height, data),
-            F::BC5RgUnorm | F::BC5RgSnorm => rgba_from_bcn::<Bc5, u8>(width, height, data),
+            F::BC4RUnorm => rgba_from_bcn::<Bc4, u8>(width, height, data),
+            F::BC4RSnorm => rgba_from_bcn::<Bc4S, u8>(width, height, data),
+            F::BC5RgUnorm => rgba_from_bcn::<Bc5, u8>(width, height, data),
+            F::BC5RgSnorm => rgba_from_bcn::<Bc5S, u8>(width, height, data),
             F::BC6hRgbUfloat | F::BC6hRgbSfloat => rgba_from_bcn::<Bc6, u8>(width, height, data),
             F::BC7RgbaUnorm | F::BC7RgbaUnormSrgb => rgba_from_bcn::<Bc7, u8>(width, height, data),
             F::R8Unorm => rgba8_from_r8(width, height, data),


### PR DESCRIPTION
This PR adds support for signed (SNORM) BC4/BC5 formats, resolving #18.
API Changes:
- `bc4` and `bc5` functions in `bcdec_rs` now take in a `is_signed` argument.
- Added `Bc4S` and `Bc5S` BC types to `image_dds`.

I don't know how to move forward with perhaps adding test data or unit tests for this code, so I would appreciate any guidance on that. However, I've tested around 10K BC5 SNORM normal maps and haven't found any issues with decompression.

Docs for BC5 (https://learn.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression) state that the last two additional values should be -1.0 and 1.0 respectively, but I've kept it the same as the UNORM variant as most implementations seem to do that